### PR TITLE
Fix enemy collision invincibility cooldown (closes #4)

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -167,6 +167,10 @@ export function updateEnemies(dt) {
           state.player.y = CANVAS_HEIGHT - 60;
           state.shield = true;
           state.shieldUntil = now() + 1400;
+          // Don't start invincibility yet - wait for user to unpause
+          state.invincible = false;
+          state.invincibleUntil = 0;
+          state._startInvincibilityAfterUnpause = true; // Flag to start invincibility after unpause
           state.respawnPauseUntil = Date.now() + 1000; // Pause for 1 second
           playSound('shield');
           state.enemyBullets = state.enemyBullets.filter(eb => Math.abs(eb.y - state.player.y) > 60);


### PR DESCRIPTION
## Summary
- Fix missing invincibility flag setup in enemy collision handler
- Now consistent with enemy bullet and boss collision behavior
- Players get 2.5 seconds of invincibility after being hit by enemies

## Changes Made
- Added `state.invincible = false`, `state.invincibleUntil = 0`, and `state._startInvincibilityAfterUnpause = true` to enemy collision handler in `js/enemy.js`
- This matches the behavior already implemented for enemy bullet and boss collisions

## Test Plan
- [x] Player hit by enemy should trigger respawn pause
- [x] After unpause, player should have 2.5 seconds of invincibility
- [x] Player should blink and turn red during invincibility period
- [x] Behavior should match other collision types

🤖 Generated with [Claude Code](https://claude.ai/code)